### PR TITLE
Fix BUILD logic fi

### DIFF
--- a/pbp-build-linux
+++ b/pbp-build-linux
@@ -172,7 +172,7 @@ if [ $CROSSBUILD = no ]; then
  if [ $MAKEDISTRO = none ]; then
   make -j `nproc`
  fi
-if
+fi
 
 ## EXIT
 exit


### PR DESCRIPTION
Ending `if` should be `fi`, otherwise you get:
````
Syntax error: end of file unexpected (expecting "then")
````