### PR TITLE
Add more dependencies to build script

### DIFF
--- a/pbp-build-linux
+++ b/pbp-build-linux
@@ -23,7 +23,9 @@ GCCARMDIR=$DEVDIR/$GCCARMPKG
 # Provide INSTALLDEPS=debian to install dependencies.
 if [ $INSTALLDEPS ]; then
  if [ $INSTALLDEPS = debian ]; then
- sudo apt-get -y install build-essential libncurses-dev wget tar xz-utils patch
+  sudo apt-get -y install \
+   build-essential libncurses-dev wget tar xz-utils patch \
+   bison flex bc rsync libssl-dev
  fi
 fi
 


### PR DESCRIPTION
Adds `bison flex bc rsync libssl-dev` to the dependencies installed. I needed these coming off a minimal MATE installation on Debian.