### PR TITLE
Add a dependency needed to be installed

### DIFF
--- a/pbp-install-linux
+++ b/pbp-install-linux
@@ -87,7 +87,7 @@ fi
 if [ $INSTALLDEPS ]; then
  if [ $INSTALLDEPS = debian ]; then
   sudo apt-get -y install build-essential coreutils libc-bin wget tar xz-utils patch \
-   libncurses-dev bison flex bc rsync libssl-dev
+   libncurses-dev bison flex bc rsync libssl-dev fakeroot
  fi
 fi
 


### PR DESCRIPTION
I found that fakeroot needed to be installed when compiling kernel.
If fakeroot is not present and the script is run as root user,it will report error 2.
And when run as normal users,it won't report this error.